### PR TITLE
feat: Implement logic to close or keep open the transcript panel

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -55,6 +55,10 @@ const getWholeText = () => {
 };
 
 const getTranscript = async () => {
+  const panelSelector = 'ytd-engagement-panel-section-list-renderer[target-id="engagement-panel-searchable-transcript"]';
+  const panel = document.querySelector(panelSelector);
+  const wasAlreadyOpen = panel && panel.getAttribute("visibility") === "ENGAGEMENT_PANEL_VISIBILITY_EXPANDED";
+
   const button = document.querySelector("ytd-video-description-transcript-section-renderer button");
   let transcriptRenderer;
 
@@ -99,6 +103,13 @@ const getTranscript = async () => {
     const textElement = segment.querySelector("yt-formatted-string");
     return textElement ? textElement.textContent.trim() : "";
   });
+
+  if (!wasAlreadyOpen) {
+    const closeButton = document.querySelector(`${panelSelector} #visibility-button button`);
+    if (closeButton) {
+      closeButton.click();
+    }
+  }
 
   return transcriptTexts.join("\n");
 };


### PR DESCRIPTION
Implemented logic to automatically close the YouTube transcript panel after retrieving the text. The panel is only closed if it was not already open before the extension was activated.

Changes:

- Added detection of the initial visibility state of the panel (wasAlreadyOpen).
- Implemented an automatic click on the close button if the panel was opened by the extension.
- Preserved the panel state if it was already open by the user.